### PR TITLE
FINISH STACK_GROWTH

### DIFF
--- a/include/vm/file.h
+++ b/include/vm/file.h
@@ -7,6 +7,12 @@ struct page;
 enum vm_type;
 
 struct file_page {
+	struct file *file;
+	off_t offset;
+	size_t page_read_bytes;
+	size_t page_zero_bytes;
+	size_t file_real_bytes;
+	bool is_start;
 };
 
 void vm_file_init (void);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -47,6 +47,14 @@ struct load_segment_passing_args{
 	size_t page_zero_bytes;
 };
 
+// struct mmap_passing_args{
+// 	void* addr;
+// 	size_t length;
+// 	int writable;
+// 	struct file* file;
+// 	off_t offset;
+// };
+
 /* The representation of "page".
  * This is kind of "parent class", which has four "child class"es, which are
  * uninit_page, file_page, anon_page, and page cache (project4).
@@ -136,5 +144,7 @@ unsigned page_hash (const struct hash_elem *p_, void *aux UNUSED);
 bool page_less (const struct hash_elem *a_, const struct hash_elem *b_, void *aux UNUSED);
 
 bool is_stack(struct page *);
+
+void printf_hash(struct supplemental_page_table *spt);
 
 #endif  /* VM_VM_H */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -760,14 +760,9 @@ lazy_load_segment (struct page *page, void *aux) {
 	/* Load this page. */
 	if (file_read (file, page->frame->kva, page_read_bytes) != (int) page_read_bytes) {
 		palloc_free_page (page->frame->kva);
-      
 		return false;
 	}
 	memset(page->frame->kva + page_read_bytes, 0, page_zero_bytes);
-   // writable 재설정
-   // pml4_clear_page(thread_current()->pml4, page->va);
-   // printf("va : %X, writable :%d\n", page->va, page->writable); 
-   pml4_set_page(thread_current()->pml4, page->va, page->frame->kva, page->writable); 
 	free(aux);
 	return true;
 }
@@ -833,11 +828,9 @@ setup_stack (struct intr_frame *if_) {
     * TODO: You should mark the page is stack. */
    /* TODO: Your code goes here */
 
-   if (vm_alloc_page(VM_ANON, stack_bottom, true)){
-      success = vm_claim_page(stack_bottom);
-      struct page * stack_page = spt_find_page(&thread_current()->spt, stack_bottom);
-      stack_page->vm_type+=VM_STACK_MARKER;
-   }
+   success = vm_claim_page(stack_bottom);
+   struct page * stack_page = spt_find_page(&thread_current()->spt, stack_bottom);
+   stack_page->vm_type+=VM_STACK_MARKER;
 
    // 비트 마킹하기
    if (success){

--- a/vm/file.c
+++ b/vm/file.c
@@ -1,6 +1,8 @@
 /* file.c: Implementation of memory backed file object (mmaped object). */
 
 #include "vm/vm.h"
+#include "threads/mmu.h"
+#include <round.h>
 
 static bool file_backed_swap_in (struct page *page, void *kva);
 static bool file_backed_swap_out (struct page *page);
@@ -23,9 +25,11 @@ vm_file_init (void) {
 bool
 file_backed_initializer (struct page *page, enum vm_type type, void *kva) {
 	/* Set up the handler */
+	// printf("file_backed_initializer\n");
 	page->operations = &file_ops;
-
+	page->vm_type = VM_TYPE(type);
 	struct file_page *file_page = &page->file;
+	return true;
 }
 
 /* Swap in the page by read contents from the file. */
@@ -43,16 +47,97 @@ file_backed_swap_out (struct page *page) {
 /* Destory the file backed page. PAGE will be freed by the caller. */
 static void
 file_backed_destroy (struct page *page) {
+	printf("file_back_dest\n");
 	struct file_page *file_page UNUSED = &page->file;
+
+	
+	printf("page->va :%X", page->va);
+	// file_write_at(file_page->file, page->va, file_page->page_read_bytes, file_page->offset);
+	file_write_at(page->file.file, page->va, page->file.page_read_bytes, page->file.offset);
+		// pml4_clear_page(thread_current()->pml4, page->va);
+	free(page);
+
 }
 
 /* Do the mmap */
 void *
 do_mmap (void *addr, size_t length, int writable,
 		struct file *file, off_t offset) {
-}
+	size_t alloc_length = ROUND_UP(length, PGSIZE);
+	void * alloc_addr = addr;
+	while(alloc_length != 0){
+		// printf("alloc_length:%d\n", alloc_length);
+		// printf("mmap writable : %d\n", writable);
+		vm_alloc_page(VM_FILE, alloc_addr, writable);
+		alloc_addr += PGSIZE;
+		alloc_length -= PGSIZE;
+	}
 
+	size_t read_bytes = file_length(file)-offset;
+	size_t zero_bytes = (ROUND_UP(read_bytes, PGSIZE) - read_bytes);
+
+	// printf("read_bytes : %d, zero_bytes :%d\n", read_bytes, zero_bytes);
+	
+	void *read_addr = addr;
+	struct page* page = NULL;
+	while (read_bytes > 0 || zero_bytes > 0) {
+		page = spt_find_page(&thread_current()->spt, read_addr);
+		// printf("page-> va : %X read_addr : %X\n", page->va, read_addr);
+		struct file_page *file_page = &page->file;
+		size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
+      	size_t page_zero_bytes = PGSIZE - page_read_bytes;
+
+		if(file_read_at(file, read_addr, page_read_bytes, offset) != page_read_bytes){
+			printf("read_bytes error\n");
+		}
+		memset(read_addr + page_read_bytes, 0, PGSIZE-page_zero_bytes);
+
+		file_page->file = file;
+		file_page->offset = offset;
+		file_page->page_read_bytes = page_read_bytes;
+		file_page->page_zero_bytes = page_zero_bytes;
+
+		
+		read_bytes -= page_read_bytes;
+		zero_bytes -= page_zero_bytes;
+		read_addr += PGSIZE;
+		offset += page_read_bytes;
+	}
+	// 시작지점 체크
+	page = spt_find_page(&thread_current()->spt, addr);
+	page->file.is_start=true;
+	
+}
+#include "vm/vm.h"
 /* Do the munmap */
 void
 do_munmap (void *addr) {
+	void* write_addr = addr;
+	struct page* page = NULL;
+	while(1){
+		struct page* page = spt_find_page(&thread_current()->spt, write_addr);
+		if(page == NULL){
+			break;
+		}
+		destroy(page);
+		// if(page->vm_type != VM_TYPE(VM_FILE) 
+		// 	|| ( page->vm_type != VM_TYPE(VM_UNINIT) || page->uninit.type != VM_TYPE(VM_FILE) ))
+		// 	break;
+			
+		// if(page->vm_type == VM_TYPE(VM_FILE)){
+		// 	// printf("page->va :%X", page->va);
+		// 	file_write_at(page->file.file, page->va, page->file.page_read_bytes, page->file.offset);
+		// }
+		// else if(page->vm_type == VM_TYPE(VM_UNINIT) && page->uninit.type == VM_TYPE(VM_FILE)){
+		// 	printf("uninit todo\n");
+		// }
+		// else{
+		// 	break;
+		// }
+		write_addr+= PGSIZE;
+	}
+	printf("munmap_end!!!\n");
+	
+	
+
 }

--- a/vm/uninit.c
+++ b/vm/uninit.c
@@ -45,15 +45,38 @@ uninit_new (struct page *page, void *va, vm_initializer *init,
 /* Initalize the page on first fault */
 static bool
 uninit_initialize (struct page *page, void *kva) {
+	// printf("uninit initialzier\n"); 
 	struct uninit_page *uninit = &page->uninit;
-
 	/* Fetch first, page_initialize may overwrite the values */
 	vm_initializer *init = uninit->init;
 	void *aux = uninit->aux;
+	// printf("va: %X, uninit->type: %d\n", page->va, uninit->type);
 
-	/* TODO: You may need to fix this function. */
+
+	// if(VM_TYPE(uninit->type) == VM_ANON){
 	return uninit->page_initializer (page, uninit->type, kva) &&
 		(init ? init (page, aux) : true);
+	// }	
+
+	// else if(VM_TYPE(uninit->type) == VM_FILE){
+	// 	// struct file_page* file_page = (struct file_page*)aux;
+	// 	// void *addr = mmap_passing_args->addr;
+	// 	// size_t length = mmap_passing_args->length;
+	// 	// int writable = mmap_passing_args->writable;
+	// 	// struct file *file = mmap_passing_args->file;
+	// 	// off_t offset = mmap_passing_args->offset;
+	// 	struct uninit_page *uninit_mal = (struct uninit_page *) malloc(sizeof(struct uninit_page));
+	// 	memcpy(uninit_mal, uninit, sizeof(struct uninit_page));
+	// 	memcpy(&page->file, aux, sizeof(struct file_page));
+	// 	free(aux);
+	// 	// printf("page->file->file:%X, page->file->offset : %d, r_b : %d, z_b: %d, is_start: %d\n", page->file.file, page->file.offset, page->file.page_read_bytes, page->file.page_zero_bytes, page->file.is_start);
+
+	// 	uninit_mal->page_initializer(page, VM_FILE, kva);
+	// 	free(uninit_mal);
+	// 	return true;
+	// 	// return uninit->page_initializer (page, VM_FILE, kva) &&
+	// 	// (init ? init (page, aux) : true);
+	// }
 }
 
 /* Free the resources hold by uninit_page. Although most of pages are transmuted

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -72,7 +72,6 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		/* 페이지를 생성하고 VM 유형에 따라 초기값을 가져온 다음 uninit_new를 호출하여 "uninit" 페이지 구조체를 생성합니다. 
 			uninit_new를 호출한 후 필드를 수정해야 합니다. 페이지를 spt에 삽입합니다.*/
 		new_page = (struct page *)malloc(sizeof(struct page));
-
 		switch (VM_TYPE(type))
 		{
 		case VM_ANON:
@@ -84,9 +83,10 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		}
 		if (!spt_insert_page(spt, new_page))
 			goto err;
+		new_page->writable = writable;
+		new_page->vm_type = VM_TYPE(VM_UNINIT);
 	}
-	new_page->writable = writable;
-	new_page->vm_type = VM_TYPE(VM_UNINIT);
+	// printf("check va : %X wtb : %d\n", new_page->va, new_page->writable);
 
 	return true;
 err:
@@ -207,6 +207,10 @@ vm_stack_growth (void *addr UNUSED) {
 /* Handle the fault on write_protected page */
 static bool
 vm_handle_wp (struct page *page UNUSED) {
+	if (page->writable)
+		return true;
+	else
+		return false;
 }
 
 /* Return true on success */
@@ -218,48 +222,32 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 	/* TODO: Validate the fault */
 	/* TODO: Your code goes here */
 	//유저 스페이스를 가리키고 있어야 함
+	// printf("addr: %X, write : %d\n", addr,write);
 	if (is_kernel_vaddr(addr))
 		return false;
-
-	page = spt_find_page(spt, pg_round_down(addr));
-	if (page != NULL) {
-		return vm_do_claim_page(page);
-	}
-
 	// 유저 주소를 가르키고 있으면 tf->rsp 그대로 사용
 	void * stack_pointer = f->rsp;
-	//커널 주소를 가리키고 있으면 syscall_handler에서 직접 thread 구조체에 넣어준 값으로
-	if (is_kernel_vaddr(f->rsp)) 
-		stack_pointer = thread_current()->stack_pointer; 
 	
-	// printf("fault==========\n");
-	// printf("fault_addr : %X stack_pointer :%X f->rsp : %X thread_current()->stack_pointer : %X\n", addr, stack_pointer, f->rsp, thread_current()->stack_pointer);
+	//커널 주소를 가리키고 있으면 syscall_handler에서 직접 thread 구조체에 넣어준 값으로
+	if (is_kernel_vaddr(f->rsp))
+		stack_pointer = thread_current()->stack_pointer;
+	page = spt_find_page(spt, pg_round_down(addr));
+
+	if (page != NULL) {
+		// // 권한이 읽기인데 쓰려는 경우
+		// if (vm_handle_wp(page) == false && (write == true))
+		// 	return false;
+		return vm_do_claim_page(page);
+	}
 
 	// frame과 연결이 되지 않으면
 	if (addr <= USER_STACK && addr >= USER_STACK - 0x100000  && addr >= pg_round_down(stack_pointer)){
 		vm_stack_growth(addr);
 		return true;
 	}
-
-	return false;
+	else 
+		return false;
 }
-
-
-// bool
-// is_vm_stack(void* addr){
-// 	printf("stack_growth start\n");
-// 	struct intr_frame *f = &thread_current()->tf;
-// 		printf("right : %d\n", addr <= USER_STACK && addr >= USER_STACK - 0x100000 && addr >= pg_round_down(f->rsp));
-
-// 	if (addr <= USER_STACK && addr >= USER_STACK - 0x100000 && addr >= pg_round_down(f->rsp)){
-// 		printf("stack_growth_work");
-// 	// if (addr <= USER_STACK && addr >= USER_STACK - 0x100000){
-// 		return true;
-// 	}
-// 	else{
-// 		return false;
-// 	}
-// }
 
 
 /* Free the page.
@@ -279,11 +267,10 @@ bool
 vm_claim_page (void *va UNUSED) {
 	/* TODO: Fill this function */
 	struct thread *curr = thread_current();
-	struct page *page = NULL;	
+	struct page *page = NULL;
 	va = pg_round_down(va);
 	
 	ASSERT(pg_ofs (va) == 0 ); // 추가한 검증
-
 	vm_alloc_page(VM_ANON, va, true);
 	page = spt_find_page(&curr->spt, va);
 	return vm_do_claim_page (page);
@@ -294,6 +281,7 @@ static bool
 vm_do_claim_page (struct page *page) {
 	struct frame *frame = vm_get_frame ();
 	struct thread *curr = thread_current();
+	// printf("claim_page page->va : %X!!!\n", page->va);
 
 	/* Set links */
 	frame->page = page;
@@ -301,7 +289,10 @@ vm_do_claim_page (struct page *page) {
 
 	/* TODO: Insert page table entry to map page's VA to frame's PA. */
 	// 페이지 테이블 항목을 삽입하여 페이지의 VA를 프레임의 PA에 매핑합니다.
-	pml4_set_page(curr->pml4, page->va, frame->kva, true);
+	if(pml4_get_page(curr->pml4, page->va))
+		return false;
+		// PANIC("Already mapped"); // 추가 검증 로직
+	pml4_set_page(curr->pml4, page->va, frame->kva, page->writable);
 	return swap_in (page, frame->kva);
 }
 
@@ -356,26 +347,36 @@ supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
    	while (hash_next (&i))
    	{	
 		struct page *sp = hash_entry(hash_cur(&i), struct page, hash_elem);
-		// printf("type: %d", sp->vm_type);
 		vm_initializer *init = NULL;
+		struct page *dp = NULL;
 		// 부모 page가 UNINIT
 		// if( sp->frame == NULL){
 		switch (VM_TYPE(sp->vm_type))
 		{
-		case VM_UNINIT:
-			init = sp->uninit.init;
-			struct load_segment_passing_args* aux = (struct load_segment_passing_args*)malloc(sizeof(struct load_segment_passing_args));
-			memcpy(aux, sp->uninit.aux, sizeof(struct load_segment_passing_args));
-			vm_alloc_page_with_initializer(sp->uninit.type, sp->va, sp->writable, init, aux);
-			break;
-		
-		// 부모 page가 ANON/FILE
-		case VM_ANON:
-			vm_claim_page(sp->va);
-			struct page *dp = spt_find_page(dst, sp->va);
-			dp->writable = sp->writable;
-			memcpy(dp->frame->kva, sp->frame->kva, PGSIZE);
-			break;
+			case VM_UNINIT:
+				init = sp->uninit.init;
+				struct load_segment_passing_args* aux = (struct load_segment_passing_args*)malloc(sizeof(struct load_segment_passing_args));
+				memcpy(aux, sp->uninit.aux, sizeof(struct load_segment_passing_args));
+				vm_alloc_page_with_initializer(sp->uninit.type, sp->va, sp->writable, init, aux);
+				break;
+			
+			// 부모 page가 ANON/FILE
+			case VM_ANON:
+				vm_claim_page(sp->va);
+				dp = spt_find_page(dst, sp->va);
+				dp->writable = sp->writable;
+				memcpy(dp->frame->kva, sp->frame->kva, PGSIZE);
+				break;
+			// 부모 page가 ANON/FILE
+			case VM_FILE:
+				vm_claim_page(sp->va);
+				dp = spt_find_page(dst, sp->va);
+				dp->writable = sp->writable;
+				dp->vm_type = sp->vm_type;
+				dp->file = sp->file;
+				memcpy(dp->frame->kva, sp->frame->kva, PGSIZE);
+				break;
+			
 		}
 	}
 	return true;


### PR DESCRIPTION
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/fork-once
pass tests/userprog/fork-multiple
pass tests/userprog/fork-recursive
pass tests/userprog/fork-read
pass tests/userprog/fork-close
pass tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/exec-read
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
pass tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
pass tests/userprog/rox-child
pass tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
pass tests/vm/pt-grow-stack
pass tests/vm/pt-grow-bad
pass tests/vm/pt-big-stk-obj
pass tests/vm/pt-bad-addr
pass tests/vm/pt-bad-read
pass tests/vm/pt-write-code
pass tests/vm/pt-write-code2
pass tests/vm/pt-grow-stk-sc
pass tests/vm/page-linear
pass tests/vm/page-parallel
pass tests/vm/page-merge-seq
pass tests/vm/page-merge-par
pass tests/vm/page-merge-stk
FAIL tests/vm/page-merge-mm
pass tests/vm/page-shuffle
FAIL tests/vm/mmap-read
FAIL tests/vm/mmap-close
FAIL tests/vm/mmap-unmap
FAIL tests/vm/mmap-overlap
FAIL tests/vm/mmap-twice
FAIL tests/vm/mmap-write
pass tests/vm/mmap-ro
FAIL tests/vm/mmap-exit
FAIL tests/vm/mmap-shuffle
FAIL tests/vm/mmap-bad-fd
FAIL tests/vm/mmap-clean
FAIL tests/vm/mmap-inherit
FAIL tests/vm/mmap-misalign
FAIL tests/vm/mmap-null
FAIL tests/vm/mmap-over-code
FAIL tests/vm/mmap-over-data
FAIL tests/vm/mmap-over-stk
FAIL tests/vm/mmap-remove
pass tests/vm/mmap-zero
FAIL tests/vm/mmap-bad-fd2
FAIL tests/vm/mmap-bad-fd3
FAIL tests/vm/mmap-zero-len
FAIL tests/vm/mmap-off
FAIL tests/vm/mmap-bad-off
FAIL tests/vm/mmap-kernel
FAIL tests/vm/lazy-file
pass tests/vm/lazy-anon
FAIL tests/vm/swap-file
FAIL tests/vm/swap-anon
FAIL tests/vm/swap-iter
FAIL tests/vm/swap-fork
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
pass tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
pass tests/filesys/base/syn-write
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/vm/cow/cow-simple
30 of 141 tests failed.